### PR TITLE
ci: add least-privilege permissions block to workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,10 @@
 
 name: Node.js CI
 
+# Least-privilege token: read-only access to repo contents is all CI needs.
+permissions:
+  contents: read
+
 on:
   push:
     branches: 


### PR DESCRIPTION
Explicitly scope GITHUB_TOKEN to contents: read to satisfy the CodeQL token-permissions check. CI only checks out the repo, builds, and runs tests, so it needs no write access.