### PR TITLE
chore(deps): bump @mui/material and @mui/icons-material to v9.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
-        "@mui/icons-material": "^7.3.11",
-        "@mui/material": "^7.3.11",
+        "@mui/icons-material": "^9.2.0",
+        "@mui/material": "^9.2.0",
         "@reduxjs/toolkit": "^2.12.0",
         "@xyflow/react": "^12.11.2",
         "react": "^19.2.8",
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.11.tgz",
-      "integrity": "sha512-a7I/b/nBTdXYz2cOSlEmkQ9WWE1x8FHpqMhFPp+Y1VPFxcOw91G5ELOHARQAGSPy5V+UCgJua6K/1x70bAtQPw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.2.0.tgz",
+      "integrity": "sha512-+XMav+ZaXkZKUFUgzjrfMEedfyJKxxviAske2q8N8CWDMeqZdDU2lWMkiUPiB388hGaDqhwvOAwkrsc/pUyp8g==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -592,12 +592,12 @@
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.11.tgz",
-      "integrity": "sha512-+hz5ilwHZ3djd5es3sCErLioqe/NhZcYTsV/TNXZAMdJdb23F4xzJjqnnZdnurc3S1+ietcssRNqieOhPQLZ7Q==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-9.2.0.tgz",
+      "integrity": "sha512-VgBd3z7Qc3vd/thcNSMC03nHRh/U4DzMUd+1dRyJTbm/hGo7+N6N4GDuJZDNHa6LZhhwG6Cu1X3DNvrVv8sNag==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6"
+        "@babel/runtime": "^7.29.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -607,7 +607,7 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@mui/material": "^7.3.11",
+        "@mui/material": "^9.2.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -618,22 +618,22 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.11.tgz",
-      "integrity": "sha512-yq8bPc3LxOwKRWpcjRgDkYFmpM6aKlARfESTmOQcvLYFeJwtHte2tw6hJDrb8sk8wcvpDprHEHVaoUU0MslIkw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-9.2.0.tgz",
+      "integrity": "sha512-+YTRSgGKGrrRo2XJZXs7JRA6qHoHWvNtxyqxnrRJTBmIuLOUpxxh7m4G9lF4tWberxGFY+EqkkRPgJCl+fSMJg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/core-downloads-tracker": "^7.3.11",
-        "@mui/system": "^7.3.11",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.11",
+        "@babel/runtime": "^7.29.2",
+        "@mui/core-downloads-tracker": "^9.2.0",
+        "@mui/system": "^9.2.0",
+        "@mui/types": "^9.1.1",
+        "@mui/utils": "^9.2.0",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.3",
+        "react-is": "^19.2.6",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -646,7 +646,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.11",
+        "@mui/material-pigment-css": "^9.2.0",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -667,13 +667,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.11.tgz",
-      "integrity": "sha512-9B+YKms0fRHbNrqp9tOT/DNbNnU5gyvJ1o3qAGXfq8GmZcbJnE3At9x07Zr/o0pkhzg4aDdwXVqe4+AcgtOCPA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-9.2.0.tgz",
+      "integrity": "sha512-w9wpyDxGPGnAACPB2hKhCDmILJIAvQxrfjUbIAEa0AznX1rOjaz5N+yB1uuw8ixnJcpEh/tPbD9oEe19wcWPHw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/utils": "^7.3.11",
+        "@babel/runtime": "^7.29.2",
+        "@mui/utils": "^9.2.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -694,12 +694,12 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.10",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.10.tgz",
-      "integrity": "sha512-WxE9SiF8xskAQqGjsp0poXCkCqsoXFEsSr0HBXfApmGHR+DBnXRp+z46Vsltg4gpPM4Z96DeAQRpeAOnhNg7Ng==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-9.1.1.tgz",
+      "integrity": "sha512-neaYKdJfvEG54q8efHLJR7swpHG/gfSv9xGqW5iTSMsubD7yPCPFrhVBt284j1DOF3uZaaDJSHQL7gz6jGF21Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
+        "@babel/runtime": "^7.29.2",
         "@emotion/cache": "^11.14.0",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
@@ -728,16 +728,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.11.tgz",
-      "integrity": "sha512-7izwGWdNawAKpBKcRlx7f2gFnAAjmASBWvMcyX4YYEeLOFsbfGRbUYGInvnAcUeql3rPxI7F9Ft4oY2OLRz44g==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-9.2.0.tgz",
+      "integrity": "sha512-YvUJwKoGVtbnOm2PyPi5TvX2d1rOA6sqSpEWVs4WmXNIaFTuYmNUaVdU2o1NKUEe31URnD3E8ZVUMcsLQXwcYg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/private-theming": "^7.3.11",
-        "@mui/styled-engine": "^7.3.10",
-        "@mui/types": "^7.4.12",
-        "@mui/utils": "^7.3.11",
+        "@babel/runtime": "^7.29.2",
+        "@mui/private-theming": "^9.2.0",
+        "@mui/styled-engine": "^9.1.1",
+        "@mui/types": "^9.1.1",
+        "@mui/utils": "^9.2.0",
         "clsx": "^2.1.1",
         "csstype": "^3.2.3",
         "prop-types": "^15.8.1"
@@ -768,12 +768,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.12",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.12.tgz",
-      "integrity": "sha512-iKNAF2u9PzSIj40CjvKJWxFXJo122jXVdrmdh0hMYd+FR+NuJMkr/L88XwWLCRiJ5P1j+uyac25+Kp6YC4hu6w==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.1.1.tgz",
+      "integrity": "sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6"
+        "@babel/runtime": "^7.29.2"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -785,17 +785,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.11",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.11.tgz",
-      "integrity": "sha512-XTjGnifwteg71/ij+0e7Y7d+hwyntMYP5wPoA/g2drdGH+Flkvjwy0OfrVpKBbaOvofq4zU/LIyUZyKgmWu18g==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.2.0.tgz",
+      "integrity": "sha512-OsUH5zhlSOM4xmLl53+agug1M1UyWb4zxFxWQCqwKTKUeQPvTENtg3JhrroBD2qpCLKsX5W/DYGERJ4mBUbc8g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@mui/types": "^7.4.12",
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.1.1",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.2.3"
+        "react-is": "^19.2.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -850,6 +850,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -2284,6 +2285,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -2832,6 +2834,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -2913,6 +2916,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3079,6 +3083,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3088,7 +3093,8 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -3154,6 +3160,7 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@mui/icons-material": "^7.3.11",
-    "@mui/material": "^7.3.11",
+    "@mui/icons-material": "^9.2.0",
+    "@mui/material": "^9.2.0",
     "@reduxjs/toolkit": "^2.12.0",
     "@xyflow/react": "^12.11.2",
     "react": "^19.2.8",

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`renders app correctly 1`] = `
                   style="overflow: hidden; margin-bottom: 0px;"
                 >
                   <div
-                    class="MuiTabs-list MuiTabs-flexContainer css-hzcega-MuiTabs-list"
+                    class="MuiTabs-list css-hzcega-MuiTabs-list"
                     role="tablist"
                   >
                     <button
@@ -85,14 +85,14 @@ exports[`renders app correctly 1`] = `
               Bot stopped
             </p>
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSuccess css-frkth0-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorSuccess css-frkth0-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >
               Start
             </button>
             <button
-              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorError css-8kauh6-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorError css-8kauh6-MuiButtonBase-root-MuiButton-root"
               disabled=""
               tabindex="-1"
               type="button"
@@ -115,7 +115,7 @@ exports[`renders app correctly 1`] = `
               Flow
             </h3>
             <p
-              class="MuiTypography-root MuiTypography-body2 css-84gl1-MuiTypography-root"
+              class="MuiTypography-root MuiTypography-body2 css-r2go6j-MuiTypography-root"
             >
               Build a conversational flow by dragging nodes from the palette onto the canvas and connecting them.
             </p>
@@ -149,7 +149,7 @@ exports[`renders app correctly 1`] = `
                     >
                       <input
                         aria-invalid="false"
-                        class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1fe3xww-MuiInputBase-input-MuiOutlinedInput-input"
+                        class="MuiInputBase-input MuiOutlinedInput-input css-1fe3xww-MuiInputBase-input-MuiOutlinedInput-input"
                         id="_r_3_"
                         placeholder="Filter nodes…"
                         type="text"
@@ -180,7 +180,7 @@ exports[`renders app correctly 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <span
-                        class="MuiTypography-root MuiTypography-overline css-15eh799-MuiTypography-root"
+                        class="MuiTypography-root MuiTypography-overline css-1v8utp5-MuiTypography-root"
                         data-testid="palette-group-start"
                       >
                         Start
@@ -213,12 +213,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Start
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-start"
                           >
                             Flow entry point.
@@ -230,7 +230,7 @@ exports[`renders app correctly 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <span
-                        class="MuiTypography-root MuiTypography-overline css-ew2t7n-MuiTypography-root"
+                        class="MuiTypography-root MuiTypography-overline css-m0mf3t-MuiTypography-root"
                         data-testid="palette-group-transform"
                       >
                         Transform
@@ -263,12 +263,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Lowercase
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-lowercase"
                           >
                             Make text lowercase.
@@ -303,12 +303,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Uppercase
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-uppercase"
                           >
                             Make text uppercase.
@@ -343,12 +343,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Trim
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-trim"
                           >
                             Remove surrounding spaces.
@@ -383,12 +383,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Replace
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-replace"
                           >
                             Find and replace text.
@@ -423,12 +423,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Extract Regex
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-extractRegex"
                           >
                             Keep text matching a pattern.
@@ -463,12 +463,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Random Number
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-randomNumber"
                           >
                             Replace with a random number.
@@ -480,7 +480,7 @@ exports[`renders app correctly 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <span
-                        class="MuiTypography-root MuiTypography-overline css-pz2dns-MuiTypography-root"
+                        class="MuiTypography-root MuiTypography-overline css-cf6pq7-MuiTypography-root"
                         data-testid="palette-group-condition"
                       >
                         Condition
@@ -514,12 +514,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Equals
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-equals"
                           >
                             Message equals the value.
@@ -554,12 +554,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Contains
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-contains"
                           >
                             Message contains the value.
@@ -594,12 +594,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Starts With
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-startsWith"
                           >
                             Message starts with the value.
@@ -634,12 +634,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Ends With
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-endsWith"
                           >
                             Message ends with the value.
@@ -674,12 +674,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Not Equals
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-notEquals"
                           >
                             Message is not equal to the value.
@@ -714,12 +714,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Not Contains
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-notContains"
                           >
                             Message does not contain the value.
@@ -731,7 +731,7 @@ exports[`renders app correctly 1`] = `
                       class="MuiBox-root css-0"
                     >
                       <span
-                        class="MuiTypography-root MuiTypography-overline css-o0zehk-MuiTypography-root"
+                        class="MuiTypography-root MuiTypography-overline css-1m6bad7-MuiTypography-root"
                         data-testid="palette-group-send"
                       >
                         Send
@@ -764,12 +764,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Send
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-send"
                           >
                             Send one or more messages.
@@ -804,12 +804,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Random
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-random"
                           >
                             Send one random option.
@@ -844,12 +844,12 @@ exports[`renders app correctly 1`] = `
                           class="MuiBox-root css-0"
                         >
                           <p
-                            class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                           >
                             Poll
                           </p>
                           <span
-                            class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                            class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                             data-testid="palette-desc-poll"
                           >
                             Send a Telegram poll.
@@ -878,7 +878,7 @@ exports[`renders app correctly 1`] = `
                     class="MuiBox-root css-cba58j"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-fullWidth css-3803pd-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-sizeSmall MuiButton-colorPrimary MuiButton-fullWidth css-3803pd-MuiButtonBase-root-MuiButton-root"
                       data-testid="flow-sample-Dice Bot"
                       tabindex="0"
                       type="button"
@@ -886,7 +886,7 @@ exports[`renders app correctly 1`] = `
                       Dice Bot
                     </button>
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-fullWidth css-3803pd-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-sizeSmall MuiButton-colorPrimary MuiButton-fullWidth css-3803pd-MuiButtonBase-root-MuiButton-root"
                       data-testid="flow-sample-Poll Bot"
                       tabindex="0"
                       type="button"
@@ -953,7 +953,7 @@ exports[`renders app correctly 1`] = `
             >
               Copyright ©
               <a
-                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways _url_6aa106 css-drt9hv-MuiTypography-root-MuiLink-root"
+                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways _url_6aa106 css-1ghx3tx-MuiTypography-root-MuiLink-root"
                 href="https://jh123x.com/"
               >
                 Jh123x
@@ -993,7 +993,7 @@ exports[`renders app correctly 1`] = `
                 style="overflow: hidden; margin-bottom: 0px;"
               >
                 <div
-                  class="MuiTabs-list MuiTabs-flexContainer css-hzcega-MuiTabs-list"
+                  class="MuiTabs-list css-hzcega-MuiTabs-list"
                   role="tablist"
                 >
                   <button
@@ -1046,14 +1046,14 @@ exports[`renders app correctly 1`] = `
             Bot stopped
           </p>
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorSuccess css-frkth0-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorSuccess css-frkth0-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
             Start
           </button>
           <button
-            class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorError css-8kauh6-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root Mui-disabled MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorError css-8kauh6-MuiButtonBase-root-MuiButton-root"
             disabled=""
             tabindex="-1"
             type="button"
@@ -1076,7 +1076,7 @@ exports[`renders app correctly 1`] = `
             Flow
           </h3>
           <p
-            class="MuiTypography-root MuiTypography-body2 css-84gl1-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body2 css-r2go6j-MuiTypography-root"
           >
             Build a conversational flow by dragging nodes from the palette onto the canvas and connecting them.
           </p>
@@ -1110,7 +1110,7 @@ exports[`renders app correctly 1`] = `
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1fe3xww-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input css-1fe3xww-MuiInputBase-input-MuiOutlinedInput-input"
                       id="_r_3_"
                       placeholder="Filter nodes…"
                       type="text"
@@ -1141,7 +1141,7 @@ exports[`renders app correctly 1`] = `
                     class="MuiBox-root css-0"
                   >
                     <span
-                      class="MuiTypography-root MuiTypography-overline css-15eh799-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-overline css-1v8utp5-MuiTypography-root"
                       data-testid="palette-group-start"
                     >
                       Start
@@ -1174,12 +1174,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Start
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-start"
                         >
                           Flow entry point.
@@ -1191,7 +1191,7 @@ exports[`renders app correctly 1`] = `
                     class="MuiBox-root css-0"
                   >
                     <span
-                      class="MuiTypography-root MuiTypography-overline css-ew2t7n-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-overline css-m0mf3t-MuiTypography-root"
                       data-testid="palette-group-transform"
                     >
                       Transform
@@ -1224,12 +1224,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Lowercase
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-lowercase"
                         >
                           Make text lowercase.
@@ -1264,12 +1264,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Uppercase
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-uppercase"
                         >
                           Make text uppercase.
@@ -1304,12 +1304,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Trim
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-trim"
                         >
                           Remove surrounding spaces.
@@ -1344,12 +1344,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Replace
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-replace"
                         >
                           Find and replace text.
@@ -1384,12 +1384,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Extract Regex
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-extractRegex"
                         >
                           Keep text matching a pattern.
@@ -1424,12 +1424,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Random Number
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-randomNumber"
                         >
                           Replace with a random number.
@@ -1441,7 +1441,7 @@ exports[`renders app correctly 1`] = `
                     class="MuiBox-root css-0"
                   >
                     <span
-                      class="MuiTypography-root MuiTypography-overline css-pz2dns-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-overline css-cf6pq7-MuiTypography-root"
                       data-testid="palette-group-condition"
                     >
                       Condition
@@ -1475,12 +1475,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Equals
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-equals"
                         >
                           Message equals the value.
@@ -1515,12 +1515,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Contains
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-contains"
                         >
                           Message contains the value.
@@ -1555,12 +1555,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Starts With
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-startsWith"
                         >
                           Message starts with the value.
@@ -1595,12 +1595,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Ends With
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-endsWith"
                         >
                           Message ends with the value.
@@ -1635,12 +1635,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Not Equals
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-notEquals"
                         >
                           Message is not equal to the value.
@@ -1675,12 +1675,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Not Contains
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-notContains"
                         >
                           Message does not contain the value.
@@ -1692,7 +1692,7 @@ exports[`renders app correctly 1`] = `
                     class="MuiBox-root css-0"
                   >
                     <span
-                      class="MuiTypography-root MuiTypography-overline css-o0zehk-MuiTypography-root"
+                      class="MuiTypography-root MuiTypography-overline css-1m6bad7-MuiTypography-root"
                       data-testid="palette-group-send"
                     >
                       Send
@@ -1725,12 +1725,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Send
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-send"
                         >
                           Send one or more messages.
@@ -1765,12 +1765,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Random
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-random"
                         >
                           Send one random option.
@@ -1805,12 +1805,12 @@ exports[`renders app correctly 1`] = `
                         class="MuiBox-root css-0"
                       >
                         <p
-                          class="MuiTypography-root MuiTypography-body2 css-x3la98-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-body2 css-846dai-MuiTypography-root"
                         >
                           Poll
                         </p>
                         <span
-                          class="MuiTypography-root MuiTypography-caption css-jnwefi-MuiTypography-root"
+                          class="MuiTypography-root MuiTypography-caption css-1j8qxki-MuiTypography-root"
                           data-testid="palette-desc-poll"
                         >
                           Send a Telegram poll.
@@ -1839,7 +1839,7 @@ exports[`renders app correctly 1`] = `
                   class="MuiBox-root css-cba58j"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-fullWidth css-3803pd-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-sizeSmall MuiButton-colorPrimary MuiButton-fullWidth css-3803pd-MuiButtonBase-root-MuiButton-root"
                     data-testid="flow-sample-Dice Bot"
                     tabindex="0"
                     type="button"
@@ -1847,7 +1847,7 @@ exports[`renders app correctly 1`] = `
                     Dice Bot
                   </button>
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-fullWidth css-3803pd-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-sizeSmall MuiButton-colorPrimary MuiButton-fullWidth css-3803pd-MuiButtonBase-root-MuiButton-root"
                     data-testid="flow-sample-Poll Bot"
                     tabindex="0"
                     type="button"
@@ -1914,7 +1914,7 @@ exports[`renders app correctly 1`] = `
           >
             Copyright ©
             <a
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways _url_6aa106 css-drt9hv-MuiTypography-root-MuiLink-root"
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways _url_6aa106 css-1ghx3tx-MuiTypography-root-MuiLink-root"
               href="https://jh123x.com/"
             >
               Jh123x

--- a/src/component/AppSettings.tsx
+++ b/src/component/AppSettings.tsx
@@ -331,10 +331,12 @@ export const AppSettings = () => {
             <TextField
               type="number"
               size="small"
-              inputProps={{
-                min: 1,
-                step: 1,
-                "aria-label": "Poll rate in seconds",
+              slotProps={{
+                input: {
+                  min: 1,
+                  step: 1,
+                  "aria-label": "Poll rate in seconds",
+                },
               }}
               value={pollRate}
               onChange={(e) => handlePollRateChange(e.target.value)}

--- a/src/component/TokenSaver.tsx
+++ b/src/component/TokenSaver.tsx
@@ -73,19 +73,21 @@ export const TokenSaver = () => {
               value={token}
               onChange={(e) => dispatch(setToken(e.target.value))}
               placeholder="Enter your API token"
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <Button
-                      size="small"
-                      color="primary"
-                      onClick={() => setShowToken((prev) => !prev)}
-                      sx={{ textTransform: "none", fontWeight: 600 }}
-                    >
-                      {showToken ? "Hide" : "Show"}
-                    </Button>
-                  </InputAdornment>
-                ),
+              slotProps={{
+                input: {
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <Button
+                        size="small"
+                        color="primary"
+                        onClick={() => setShowToken((prev) => !prev)}
+                        sx={{ textTransform: "none", fontWeight: 600 }}
+                      >
+                        {showToken ? "Hide" : "Show"}
+                      </Button>
+                    </InputAdornment>
+                  ),
+                },
               }}
             />
           </ListItem>

--- a/src/component/__snapshots__/Footer.test.tsx.snap
+++ b/src/component/__snapshots__/Footer.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`renders footer correctly 1`] = `
           >
             Copyright ©
             <a
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways _url_6aa106 css-drt9hv-MuiTypography-root-MuiLink-root"
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways _url_6aa106 css-1ghx3tx-MuiTypography-root-MuiLink-root"
               href="https://jh123x.com/"
             >
               Jh123x
@@ -39,7 +39,7 @@ exports[`renders footer correctly 1`] = `
         >
           Copyright ©
           <a
-            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways _url_6aa106 css-drt9hv-MuiTypography-root-MuiLink-root"
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways _url_6aa106 css-1ghx3tx-MuiTypography-root-MuiLink-root"
             href="https://jh123x.com/"
           >
             Jh123x

--- a/src/component/__snapshots__/TokenSaver.test.tsx.snap
+++ b/src/component/__snapshots__/TokenSaver.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders token saver interface correctly 1`] = `
         class="MuiStack-root css-jfdv4h-MuiStack-root"
       >
         <h2
-          class="MuiTypography-root MuiTypography-subtitle2 css-4280cv-MuiTypography-root"
+          class="MuiTypography-root MuiTypography-subtitle2 css-13tn4z9-MuiTypography-root"
         >
           BOT
         </h2>
@@ -39,7 +39,7 @@ exports[`renders token saver interface correctly 1`] = `
                 >
                   <input
                     aria-invalid="false"
-                    class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-13meb6w-MuiInputBase-input-MuiOutlinedInput-input"
+                    class="MuiInputBase-input MuiOutlinedInput-input css-13meb6w-MuiInputBase-input-MuiOutlinedInput-input"
                     id="_r_0_"
                     placeholder="Enter your API token"
                     type="password"
@@ -49,7 +49,7 @@ exports[`renders token saver interface correctly 1`] = `
                     class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-elo8k2-MuiInputAdornment-root"
                   >
                     <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1dhinlz-MuiButtonBase-root-MuiButton-root"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall MuiButton-colorPrimary css-1dhinlz-MuiButtonBase-root-MuiButton-root"
                       tabindex="0"
                       type="button"
                     >
@@ -78,7 +78,7 @@ exports[`renders token saver interface correctly 1`] = `
               class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-hq6sa7-MuiListItem-root"
             >
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-1k9hkw1-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-1k9hkw1-MuiButtonBase-root-MuiButton-root"
                 tabindex="0"
                 type="button"
               >
@@ -100,7 +100,7 @@ exports[`renders token saver interface correctly 1`] = `
       class="MuiStack-root css-jfdv4h-MuiStack-root"
     >
       <h2
-        class="MuiTypography-root MuiTypography-subtitle2 css-4280cv-MuiTypography-root"
+        class="MuiTypography-root MuiTypography-subtitle2 css-13tn4z9-MuiTypography-root"
       >
         BOT
       </h2>
@@ -130,7 +130,7 @@ exports[`renders token saver interface correctly 1`] = `
               >
                 <input
                   aria-invalid="false"
-                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedEnd css-13meb6w-MuiInputBase-input-MuiOutlinedInput-input"
+                  class="MuiInputBase-input MuiOutlinedInput-input css-13meb6w-MuiInputBase-input-MuiOutlinedInput-input"
                   id="_r_0_"
                   placeholder="Enter your API token"
                   type="password"
@@ -140,7 +140,7 @@ exports[`renders token saver interface correctly 1`] = `
                   class="MuiInputAdornment-root MuiInputAdornment-positionEnd MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-elo8k2-MuiInputAdornment-root"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1dhinlz-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-sizeSmall MuiButton-colorPrimary css-1dhinlz-MuiButtonBase-root-MuiButton-root"
                     tabindex="0"
                     type="button"
                   >
@@ -169,7 +169,7 @@ exports[`renders token saver interface correctly 1`] = `
             class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-hq6sa7-MuiListItem-root"
           >
             <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-1k9hkw1-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-sizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-1k9hkw1-MuiButtonBase-root-MuiButton-root"
               tabindex="0"
               type="button"
             >


### PR DESCRIPTION
- Update both MUI packages from 7.3.11 to 9.2.0 (latest, matching the dependabot-proposed but unmerged bumps)
- Migrate TextField InputProps/inputProps to slotProps.input API (removed in MUI v9): TokenSaver endAdornment, AppSettings poll rate
- Regenerate snapshots for MUI v9 emotion class-name changes